### PR TITLE
Mp post detail buttons

### DIFF
--- a/src/components/posts/PostDetail.js
+++ b/src/components/posts/PostDetail.js
@@ -28,12 +28,12 @@ export const PostDetail = ({ token }) => {
       <section className="myposts__content">
                   <span style={{ fontWeight: 'bold' }}>
                   <section className="subscribe__postheader"><div>{post.title}</div><div>Published On: {post?.publication_date}</div></section></span>
-      <Link to={`/users/${post.user_id}`}>
-        <h2>{post?.author?.username}</h2>
+      <Link to={`/users/${post.author_id}`}>
+        <h2>{post?.author?.full_name}</h2>
       </Link>
       <h3>{post?.category?.label}</h3>
       <section className="myposts__postbody"><p>{post.content}</p></section>
-            {parseInt(token) === post.user_id ? (
+            {parseInt(token) === post.author_id ? (
         <div className="buttons">
           <button
             onClick={(e) => {

--- a/src/components/posts/PostDetail.js
+++ b/src/components/posts/PostDetail.js
@@ -33,7 +33,7 @@ export const PostDetail = ({ token }) => {
       </Link>
       <h3>{post?.category?.label}</h3>
       <section className="myposts__postbody"><p>{post.content}</p></section>
-            {parseInt(token) === post.author_id ? (
+            {post.writer ? (
         <div className="buttons">
           <button
             onClick={(e) => {


### PR DESCRIPTION
Closes # 89


# Description of Proposed Changes

Added property decorators to post model and post_view retrieve to check if current user is also author of post in details

---


# Steps to Test

1. Fetch the `MP-Add-Comment` server branch and switch to it
2. Fetch the 'MP-AddComment' client branch and switch to it
3. run your debugger
4. login to client
5. navigate to post list
6. click on title of post. Verify that no buttons appear on details page of post not written by current user and edit/delete/view comments buttons DO appear on posts written by current user
7. proofread files changed

