### PR TITLE
added auth header to comments.js in managers

### DIFF
--- a/src/managers/comments.js
+++ b/src/managers/comments.js
@@ -1,4 +1,8 @@
 export const getCommentsByPostId = (id) => {
-    return fetch(`http://localhost:8000/comments?postId=${id}`)
+    return fetch(`http://localhost:8000/comments?postId=${id}`, {
+        headers: {
+          Authorization: `Token ${localStorage.getItem("rare_token")}`,
+        },
+    })
         .then(res => res.json())
   }


### PR DESCRIPTION
Closes Ticket # 116


# Description of Proposed Changes

Added auth headers to comment manager so get request works for list of comments by post Id
---


# Steps to Test

1. Fetch the `MP-View-Comments` branch and switch to it
2. Ensure your debugger is running in server side code
3. npm start
4. when signed in, navigate to post list
5. click on title of post
6. click on view comments button on post details page
7. You should be navigated to a comments?postID=id page and a list of comments for that post should appear

