### PR TITLE
clickable links in tag manager

### DIFF
--- a/src/components/categories/CategoryPosts.js
+++ b/src/components/categories/CategoryPosts.js
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { getPostByCat } from "../../managers/Posts";
+// import "./subscriptions.css"
+// import "../posts/Posts.css"
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { HumanDate } from "../utils/HumanDate";
+
+
+export const CategoryPosts = ({ token }) => {
+    const [catPosts, setCatPosts] = useState([]);
+    // const tokenInt = parseInt(token);
+    const {categoryId} = useParams()
+    const navigate = useNavigate()
+
+    useEffect(() => {
+        getPostByCat(categoryId).then((data) => setCatPosts(data));
+    }, []);
+
+  return <><article className="subscribe__container">
+  
+  <section className="subscribe">
+    { 
+      (catPosts.length) 
+        ? <>
+            {catPosts.map((post) => (
+              <div className="subscribe__posts">
+                <img className="subscribe__image" src={post?.image_url}/>
+                <section className="subscribe__content">
+                <span style={{ fontWeight: 'bold' }}>
+                  <section className="subscribe__postheader"><div>{post.title}</div><div>Published On: <HumanDate date={post.publication_date} /></div></section>
+                </span>
+                <h3>{post?.category?.label}</h3>
+                <section className="subscribe__postbody"><p>{post.content}</p></section>
+                <section><h3>Author: <Link to={`/users/${post.author.id}`}>
+                    {post?.author?.full_name}
+                </Link></h3>
+                </section>
+                </section>
+                </div>
+              )
+            )}
+            </>
+        : <div className="subscribe__text">There are no posts in this category yet! Make one yourself!</div>
+    }
+   </section> 
+   </article>
+   </>
+  }

--- a/src/components/tags/Tag.js
+++ b/src/components/tags/Tag.js
@@ -16,9 +16,7 @@ export const Tag = ({ tag, setterFunction }) => {
     return(
         <article className="tags__individual">
             <div>
-                <Link to={`/tags/${tag.id}`}>
-                    <h3>{tag.label}</h3>
-                </Link>
+                <h3>{tag.label}</h3>
                 <button className="editButton"
                     onClick={() => {
                         navigate({ pathname: `edit/${tag.id}` })

--- a/src/managers/Posts.js
+++ b/src/managers/Posts.js
@@ -80,5 +80,12 @@ export const getSearchedPosts = (searchTerm) => {
   
 }
 
-
+export const getPostByCat = (id) => {
+  return fetch(`http://localhost:8000/posts?category=${id}`, 
+  {
+    headers: {
+      "Authorization": `Token ${localStorage.getItem("rare_token")}`
+    }
+  }).then((res) => res.json())
+}
 

--- a/src/views/ApplicationViews.js
+++ b/src/views/ApplicationViews.js
@@ -18,7 +18,7 @@ import { NewTag } from "../components/tags/NewTag"
 import { PostContainer } from "../components/posts/PostContainer"
 import { EditCategory } from "../components/categories/EditCategory"
 import { EditTag } from "../components/tags/EditTag"
-
+import { CategoryPosts } from "../components/categories/CategoryPosts"
 
 // receiving 2 props from Rare.js
 // responsible for routing users to specific views depending on URL paths
@@ -47,6 +47,7 @@ export const ApplicationViews = ({ token, setToken }) => {
             <Route index element={<Categories token={token} />} />
             <Route path="create" element={<NewCategory token={token} />} />
             <Route path="edit/:categoryId" element={<EditCategory token={token} />} />
+            <Route path=":categoryId" element={<CategoryPosts token={token} />} />
           </Route>
           <Route path="/tags">
             <Route index element={<TagList token={token} />} />


### PR DESCRIPTION
Closes Ticket #103 


# Description of Proposed Changes
When you are on category manager, the links are clickable and take you to a filtered list of posts in that category
---


# Steps to Test

1. Fetch the `EVN-updateTagMan` branch and switch to it
2. Make sure your server is up to date with last PR and database seeded
3. Navigate to Category manager and ensure when you click Travel, there are 2 posts, and only 1 on each other category

