### PR TITLE
post reactions and reaction counters added to all post pages

### DIFF
--- a/src/components/categories/CategoryPosts.js
+++ b/src/components/categories/CategoryPosts.js
@@ -4,6 +4,7 @@ import { getPostByCat } from "../../managers/Posts";
 // import "../posts/Posts.css"
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { HumanDate } from "../utils/HumanDate";
+import { PostReactions } from "../reactions/PostReactions";
 
 
 export const CategoryPosts = ({ token }) => {
@@ -34,6 +35,13 @@ export const CategoryPosts = ({ token }) => {
                 <section><h3>Author: <Link to={`/users/${post.author.id}`}>
                     {post?.author?.full_name}
                 </Link></h3>
+                <button onClick={() => navigate(`/posts/${post.id}/comments`)}>
+                      VIEW COMMENTS
+                    </button>
+                    <button onClick={() => navigate(`/posts/${post.id}/comment`)}>ADD COMMENT</button>
+                <section>
+                      <PostReactions postId={post.id} />
+                    </section>
                 </section>
                 </section>
                 </div>

--- a/src/components/comments/Comment.js
+++ b/src/components/comments/Comment.js
@@ -1,6 +1,6 @@
 export const Comment = ({ comment }) => (
   <section className="comments__card">
     <h3>"{comment?.content}"</h3>
-    <div className="comment__author">-{comment?.user?.username}</div>
+    <div className="comment__author">-{comment?.author?.full_name}</div>
   </section>
 );

--- a/src/components/posts/MyPosts.js
+++ b/src/components/posts/MyPosts.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { deletePosts, getCurrentUserPosts } from "../../managers/Posts";
+import { PostReactions } from "../reactions/PostReactions";
 import { HumanDate } from "../utils/HumanDate";
 import "./Posts.css";
 
@@ -61,6 +62,9 @@ export const MyPosts = ({ token }) => {
           </button>
         <button onClick={() => navigate(`/posts/${post.id}/comment`)}>ADD COMMENT</button>
                   </div>
+                <section>
+        <PostReactions postId={post.id}/>
+      </section>
                 </section>
             </div>
       ))}

--- a/src/components/posts/PostDetail.js
+++ b/src/components/posts/PostDetail.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { getSinglePost } from "../../managers/Posts";
 import { deletePosts } from "../../managers/Posts";
+import { PostReactions } from "../reactions/PostReactions";
 import { HumanDate } from "../utils/HumanDate";
 import "./Posts.css";
 
@@ -33,6 +34,7 @@ export const PostDetail = ({ token }) => {
       </Link>
       <h3>{post?.category?.label}</h3>
       <section className="myposts__postbody"><p>{post.content}</p></section>
+      <section className="myposts__footer">
             {post.writer ? (
         <div className="buttons">
           <button
@@ -46,6 +48,7 @@ export const PostDetail = ({ token }) => {
             onClick={() => {
               navigate(`/posts/editpost/${post.id}`);
             }}
+            
           >
             EDIT
           </button>
@@ -61,6 +64,11 @@ export const PostDetail = ({ token }) => {
         <button onClick={() => navigate(`/posts/${postId}/comment`)}>ADD COMMENT</button>
         </>
       )}
+      
+      <section>
+        <PostReactions postId={postId}/>
+      </section>
+      </section>
       </section>
     </div>
     </article>

--- a/src/components/posts/Posts.css
+++ b/src/components/posts/Posts.css
@@ -156,3 +156,9 @@
   padding: 1rem;
   margin: 1rem
 }
+
+.myposts__footer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}

--- a/src/components/reactions/PostReactions.js
+++ b/src/components/reactions/PostReactions.js
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react"
+import { addReactionToPost, getReactions, getReactionsForPost } from "../../managers/ReactionManager"
+import "./reaction.css"
+
+export const PostReactions = ({postId}) => {
+    const [reactions, setReactions] = useState([
+        {
+            id: 0,
+            label: "",
+            emoji_url: "",
+            emoji_icon:""
+        }
+    ])
+
+    useEffect(() => {
+        getReactionsForPost(postId)
+        .then((data) => setReactions(data))
+    }, [])
+
+    return <>
+    <section className="reaction__array">
+        {
+            reactions.map((reaction) => (
+            <>
+                <p className="reaction__count">{reaction.post_reaction_count}</p>
+                    <button className="reaction__icon"
+                    onClick={() =>
+                        addReactionToPost({post: postId, reaction: reaction.id}).then(()=>getReactionsForPost(postId)).then((data) => setReactions(data))}>{reaction.emoji_icon}</button>
+                    </>
+                ))
+        }
+    </section>
+    </>
+}

--- a/src/components/reactions/reaction.css
+++ b/src/components/reactions/reaction.css
@@ -1,0 +1,22 @@
+.reaction__icon {
+    width: 25px;
+    object-fit: cover;
+    padding: 3px;
+    border: none;
+    background-color: white;
+  }
+
+  .reaction__icon:hover {
+    width: 30px;
+    object-fit: cover;
+    padding: 1px
+  }
+
+.reaction__array {
+    display: flex;
+    flex-direction: row;
+}
+
+.reaction__count {
+    font-size: 9px
+}

--- a/src/components/subscriptions/SubscriptionList.js
+++ b/src/components/subscriptions/SubscriptionList.js
@@ -3,7 +3,8 @@ import { getSubscribedPosts } from "../../managers/Posts"
 import "./subscriptions.css"
 import "../posts/Posts.css"
 import { Link, useNavigate } from "react-router-dom"
-import { HumanDate } from "../utils/HumanDate"import { PostReactions } from "../reactions/PostReactions";
+import { HumanDate } from "../utils/HumanDate"
+import { PostReactions } from "../reactions/PostReactions";
 
 export const SubscriptionList = ({ token }) => {
   const [posts, setPosts] = useState([])
@@ -58,18 +59,22 @@ export const SubscriptionList = ({ token }) => {
                         ADD COMMENT
                       </button>
                       <section>
-                      <PostReactions postId={post.id} />
-                    </section>
+                        <PostReactions postId={post.id} />
+                      </section>
                     </section>
                   </section>
-                </section>
-              </div>
+                </div>
               )
-            )}
-            </>
-        : <div className="subscribe__text">Subscribe to authors to curate your personal homepage!</div>
-    }
-   </section> 
-   </article>
-   </>
-  }
+              )}
+              </>)
+        : (<>
+          <div className="subscribe__text">Subscribe to authors to curate your personal homepage!</div>
+          </>
+        
+      )}
+      </section>
+      </article>
+    </>
+  )
+        }
+  

--- a/src/components/subscriptions/SubscriptionList.js
+++ b/src/components/subscriptions/SubscriptionList.js
@@ -4,25 +4,25 @@ import "./subscriptions.css"
 import "../posts/Posts.css"
 import { Link, useNavigate } from "react-router-dom";
 import { HumanDate } from "../utils/HumanDate";
-
+import { PostReactions } from "../reactions/PostReactions";
 
 export const SubscriptionList = ({ token }) => {
-    const [posts, setPosts] = useState([]);
-    const tokenInt = parseInt(token);
-    const navigate = useNavigate()
+  const [posts, setPosts] = useState([]);
+  const tokenInt = parseInt(token);
+  const navigate = useNavigate()
 
-    useEffect(() => {
-      getSubscribedPosts(tokenInt).then((postData) => setPosts(postData));
-    }, []);
+  useEffect(() => {
+    getSubscribedPosts(tokenInt).then((postData) => setPosts(postData));
+  }, []);
 
   return <><article className="subscribe__container">
-  <section className="addPostButton">
+    <section className="addPostButton">
       New Post <button onClick={() => navigate("posts/newpost")}>+</button>
-  </section>
-  <section className="subscribe">
-    { 
-      (posts.length) 
-        ? <>
+    </section>
+    <section className="subscribe">
+      {
+        (posts.length)
+          ? <>
             {posts.map((post) => (
               <div className="subscribe__posts">
                 <img className="subscribe__image" src={post?.image_url} />
@@ -38,15 +38,18 @@ export const SubscriptionList = ({ token }) => {
                       VIEW COMMENTS
                     </button>
                     <button onClick={() => navigate(`/posts/${post.id}/comment`)}>ADD COMMENT</button>
+                    <section>
+                      <PostReactions postId={post.id} />
+                    </section>
                   </section>
                 </section>
               </div>
-              )
+            )
             )}
-            </>
-        : <div className="subscribe__text">Subscribe to authors to curate your personal homepage!</div>
-    }
-   </section> 
-   </article>
-   </>
-  }
+          </>
+          : <div className="subscribe__text">Subscribe to authors to curate your personal homepage!</div>
+      }
+    </section>
+  </article>
+  </>
+}

--- a/src/managers/ReactionManager.js
+++ b/src/managers/ReactionManager.js
@@ -1,0 +1,18 @@
+export const getReactionsForPost = (id) => {
+    return fetch(`http://localhost:8000/reactions?post=${id}`, {
+        headers: {
+          Authorization: `Token ${localStorage.getItem("rare_token")}`,
+        },
+      }).then((res) => res.json())
+}
+
+export const addReactionToPost = (postbody) => {
+    return fetch("http://localhost:8000/postreactions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Token ${localStorage.getItem("rare_token")}`,
+      },
+      body: JSON.stringify(postbody),
+    });
+  };


### PR DESCRIPTION
Closes #123


# Description of Proposed Changes
Post reactions display and counter added to all post details views *subscription list, category posts, my posts, post details*

---


# Steps to Test

1. Fetch the jes-post-reactions server branch and switch to it, start and run debugger, run ./seed_database.sh
2.Fetch the jes-post-reactions client branch and switch to it
3. navigate to all places you see a post with details *subscription list, category posts, my posts, post details*
4. Verify that you see the reaction emojis at the bottom
5. click on emojis and verify that the counter increases in number with every click for every emoji (removing reactions and limiting one post-reaction per user is not yet supported)

